### PR TITLE
Update Podfile to support xcode 14+

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -58,5 +58,16 @@ target 'ReanimatedWorkshop' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    # This is necessary for Xcode 14, because it signs resource bundles by default
+    # when building for devices.
+    installer.target_installation_results.pod_target_installation_results
+      .each do |pod_name, target_installation_result|
+      target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+        resource_bundle_target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I couldn't run the project because it was trying to sign everything and my personal team was not set, setting it in xcode raised further issues. I found this is a common problem when using xcode 14+ https://github.com/facebook/react-native/issues/34673

We are using a similar solution for Shop.

I'm not sure if the pod lock will need updating? My local one updated but I'm not sure if that's just noise?